### PR TITLE
Refactoring options API and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 node_modules
 .DS_Store
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: node_js
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ metalsmith.use(pagination({
 * **path** The path to render every page under.
 * **filter** A string or function used to filter files in pagination.
 * **pageMetadata** The metadata to merge with every page.
+* **noPageOne** Set to true to disable rendering of page one, useful in conjunction with first (default: `false`).
+* **pageContents** Set the contents of generated pages (default: `new Buffer('')`). Useful for [metalsmith-in-place](https://npmjs.org/package/metalsmith-in-place) (especially with `pageMetadata`).
+* **groupBy** Set the grouping algorithm manually (default: paginated by `perPage`). Useful for paginating by other factors, like year published (E.g. `date.getFullYear()`).
 
 ### Page Metadata
 
@@ -82,6 +85,7 @@ The `pageMetadata` option is optional. The object passed as `pageMetadata` is me
 Within the template you specified, you will have access to pagination specific helpers:
 
 * **pagination.num** The current page number.
+* **pagination.name** The page name from `groupBy`. It will be the page number string with the default `groupBy`.
 * **pagination.files** All the files for the current page (E.g. an array of `x` articles).
 * **pagination.pages** Links to every page in the collection (E.g. used to render pagination numbers).
 * **pagination.next** The immediately following page, if it exists.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "standard": "^2.11.0"
   },
   "dependencies": {
-    "extend": "^2.0.0",
-    "to-function": "^2.0.5"
+    "to-function": "^2.0.5",
+    "xtend": "^4.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -57,18 +57,26 @@ describe('metalsmith collections paginate', function () {
 
         expect(firstPage).to.exist
         expect(firstPage).to.not.equal(pageOne)
+        expect(firstPage.pagination.num).to.equal(1)
+        expect(firstPage.pagination.name).to.equal('1')
         expect(firstPage.pagination.next).to.equal(pageTwo)
         expect(firstPage.pagination.previous).to.not.exist
 
         expect(pageOne).to.exist
+        expect(pageOne.pagination.num).to.equal(1)
+        expect(pageOne.pagination.name).to.equal('1')
         expect(pageOne.pagination.next).to.equal(pageTwo)
         expect(pageOne.pagination.previous).to.not.exist
 
         expect(pageTwo).to.exist
+        expect(pageTwo.pagination.num).to.equal(2)
+        expect(pageTwo.pagination.name).to.equal('2')
         expect(pageTwo.pagination.next).to.equal(pageThree)
         expect(pageTwo.pagination.previous).to.equal(firstPage)
 
         expect(pageThree).to.exist
+        expect(pageThree.pagination.num).to.equal(3)
+        expect(pageThree.pagination.name).to.equal('3')
         expect(pageThree.pagination.next).to.not.exist
         expect(pageThree.pagination.previous).to.equal(pageTwo)
 
@@ -76,21 +84,19 @@ describe('metalsmith collections paginate', function () {
 
         expect(firstPage.template).to.equal('index.jade')
         expect(firstPage.pagination.num).to.equal(1)
-        expect(firstPage.pagination.pages).to.equal(
-          metadata.collections.articles.pages
-        )
+        expect(firstPage.pagination.pages).to.equal(metadata.collections.articles.pages)
 
         return done(err)
       })
     })
 
-    it('should add metadata to pages created', function (done) {
+    it('should add metadata to each page created', function (done) {
       return paginate({
         'collections.articles': {
           perPage: 3,
           template: 'index.jade',
-          first: 'articles/index.html',
           path: 'articles/page/:num/index.html',
+          pageContents: 'foobar',
           pageMetadata: {
             foo: 'bar',
             some: {
@@ -104,19 +110,20 @@ describe('metalsmith collections paginate', function () {
         var pageTwo = files['articles/page/2/index.html']
         var pageThree = files['articles/page/3/index.html']
 
-        expect(firstPage).to.exist
-        expect(firstPage.foo).to.equal('bar')
-        expect(firstPage.some.thing).to.equal(true)
+        expect(firstPage).to.not.exist
 
         expect(pageOne).to.exist
+        expect(pageOne.contents).to.equal('foobar')
         expect(pageOne.foo).to.equal('bar')
         expect(pageOne.some.thing).to.equal(true)
 
         expect(pageTwo).to.exist
+        expect(pageTwo.contents).to.equal('foobar')
         expect(pageTwo.foo).to.equal('bar')
         expect(pageTwo.some.thing).to.equal(true)
 
         expect(pageThree).to.exist
+        expect(pageThree.contents).to.equal('foobar')
         expect(pageThree.foo).to.equal('bar')
         expect(pageThree.some.thing).to.equal(true)
 
@@ -124,6 +131,71 @@ describe('metalsmith collections paginate', function () {
       })
     })
 
+    it('should omit page one output with `noPageOne` enabled', function (done) {
+      return paginate({
+        'collections.articles': {
+          template: 'index.jade',
+          first: 'index.html',
+          noPageOne: true,
+          path: 'page/:num/index.html'
+        }
+      })(files, metalsmith, function (err) {
+        var firstPage = files['index.html']
+        var pageOne = files['page/1/index.html']
+
+        expect(firstPage).to.exist
+        expect(firstPage.pagination.files.length).to.equal(7)
+
+        expect(pageOne).to.not.exist
+
+        return done(err)
+      })
+    })
+  })
+
+  describe('group by', function () {
+    var files
+
+    var metadata = {
+      collections: {
+        articles: [
+          { contents: '', date: new Date(2014, 10, 7) },
+          { contents: '', date: new Date(2014, 11, 12) },
+          { contents: '', date: new Date(2015, 9, 23) }
+        ]
+      }
+    }
+
+    var metalsmith = instance(metadata)
+
+    beforeEach(function () {
+      files = {}
+    })
+
+    it('should allow custom group by functions', function (done) {
+      return paginate({
+        'collections.articles': {
+          groupBy: 'date.getFullYear()',
+          template: 'index.jade',
+          path: 'articles/:name/index.html'
+        }
+      })(files, metalsmith, function (err) {
+        var pageOne = files['articles/2014/index.html']
+        var pageTwo = files['articles/2015/index.html']
+
+        expect(pageOne).to.exist
+        expect(pageOne.pagination.num).to.equal(1)
+        expect(pageOne.pagination.name).to.equal('2014')
+        expect(pageOne.pagination.files.length).to.equal(2)
+
+        expect(pageTwo).to.exist
+        expect(pageTwo.pagination.num).to.equal(2)
+        expect(pageTwo.pagination.name).to.equal('2015')
+        expect(pageTwo.pagination.files.length).to.equal(1)
+
+        return done(err)
+      })
+    })
   })
 
   describe('filtering', function () {
@@ -242,7 +314,6 @@ describe('metalsmith collections paginate', function () {
         return done(err)
       })
     })
-
   })
 
   describe('missing array error', function () {
@@ -256,6 +327,20 @@ describe('metalsmith collections paginate', function () {
         }
       })(files, metalsmith, function (err) {
         expect(err).to.exist
+        expect(err.message).to.equal('Collection not found (articles)')
+
+        return done()
+      })
+    })
+
+    it('should error when the reference does not exist', function (done) {
+      return paginate({
+        'collections.articles': {
+          template: 'index.jade'
+        }
+      })(files, metalsmith, function (err) {
+        expect(err).to.exist
+        expect(err.message).to.equal('Collection not found (collections.articles)')
 
         return done()
       })
@@ -272,7 +357,7 @@ describe('metalsmith collections paginate', function () {
         }
       }), function (err) {
         expect(err).to.exist
-        expect(err.message).to.equal('Specify a template or layout for "collections.articles" pages')
+        expect(err.message).to.equal('A template or layout is required (collections.articles)')
 
         return done()
       })
@@ -289,7 +374,7 @@ describe('metalsmith collections paginate', function () {
         }
       }), function (err) {
         expect(err).to.exist
-        expect(err.message).to.equal('Specify a path for "collections.articles" pages')
+        expect(err.message).to.equal('The path is required (collections.articles)')
 
         return done()
       })
@@ -308,7 +393,22 @@ describe('metalsmith collections paginate', function () {
         }
       }), function (err) {
         expect(err).to.exist
-        expect(err.message).to.equal('You should not specify template and layout for "collections.articles" pages simultaneosly')
+        expect(err.message).to.equal('Template and layout can not be used simultaneosly (collections.articles)')
+
+        return done()
+      })
+    })
+
+    it('should error when `noPageOne` is enabled, but `first` is missing', function (done) {
+      return paginate({
+        'posts': {
+          template: 'index.jade',
+          noPageOne: true,
+          path: '123'
+        }
+      })({}, instance({ posts: [] }), function (err) {
+        expect(err).to.exist
+        expect(err.message).to.equal('When `noPageOne` is enabled, a first page must be set (posts)')
 
         return done()
       })


### PR DESCRIPTION
- Enable `noPageOne` configuration (Refs: #5)
- Enable `groupBy` configuration (Refs: #6)
- Enable `pageContents` configuration (Refs: #7)

Together, these options allow disabling page one rendering, grouping by custom logic (E.g. not pagination, but other file information - author, year, id, etc.) and setting default page contents (overriding the empty buffer default).
