### PR TITLE
Fixes #19 - path option arguments don't work correctly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/metalsmith-pagination.js
+++ b/metalsmith-pagination.js
@@ -31,7 +31,8 @@ module.exports = function (options) {
       // Catch nested collection reference errors.
       try {
         collection = toFn(name)(metadata)
-      } catch (error) {}
+      } catch (error) {
+      }
 
       if (!collection) {
         done(new TypeError('Collection not found (' + name + ')'))
@@ -160,9 +161,11 @@ module.exports = function (options) {
  * @return {String}
  */
 function interpolate (path, data) {
-  return path.replace(/:(\w+)/g, function (match, param) {
-    return data[param]
+  var result = path
+  Object.keys(data).forEach(function (param) {
+    result = result.replace(new RegExp(':' + param, 'g'), data[param])
   })
+  return result
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -24,13 +24,13 @@ describe('metalsmith collections paginate', function () {
     var metadata = {
       collections: {
         articles: [
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' }
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''}
         ]
       }
     }
@@ -174,6 +174,26 @@ describe('metalsmith collections paginate', function () {
         return done(err)
       })
     })
+
+    it('should replace path arguments correctly', function (done) {
+      return paginate({
+        'collections.articles': {
+          template: 'index.jade',
+          first: 'index.html',
+          path: 'page/:numen.html'
+        }
+      })(files, metalsmith, function (err) {
+        var firstPage = files['index.html']
+        var pageOne = files['page/1en.html']
+
+        expect(firstPage).to.exist
+        expect(firstPage.pagination.files.length).to.equal(7)
+
+        expect(pageOne).to.exist
+
+        return done(err)
+      })
+    })
   })
 
   describe('group by', function () {
@@ -182,9 +202,9 @@ describe('metalsmith collections paginate', function () {
     var metadata = {
       collections: {
         articles: [
-          { contents: '', date: new Date(2014, 10, 7) },
-          { contents: '', date: new Date(2014, 11, 12) },
-          { contents: '', date: new Date(2015, 9, 23) }
+          {contents: '', date: new Date(2014, 10, 7)},
+          {contents: '', date: new Date(2014, 11, 12)},
+          {contents: '', date: new Date(2015, 9, 23)}
         ]
       }
     }
@@ -227,13 +247,13 @@ describe('metalsmith collections paginate', function () {
     var metadata = {
       collections: {
         articles: [
-          { contents: '', hide: true },
-          { contents: '', hide: true },
-          { contents: '', hide: true },
-          { contents: '', hide: false },
-          { contents: '', hide: false },
-          { contents: '', hide: false },
-          { contents: '', hide: false }
+          {contents: '', hide: true},
+          {contents: '', hide: true},
+          {contents: '', hide: true},
+          {contents: '', hide: false},
+          {contents: '', hide: false},
+          {contents: '', hide: false},
+          {contents: '', hide: false}
         ]
       }
     }
@@ -429,7 +449,7 @@ describe('metalsmith collections paginate', function () {
           noPageOne: true,
           path: '123'
         }
-      })({}, instance({ posts: [] }), function (err) {
+      })({}, instance({posts: []}), function (err) {
         expect(err).to.exist
         expect(err.message).to.equal('When `noPageOne` is enabled, a first page must be set (posts)')
 


### PR DESCRIPTION
This commit fixes the interpolate method. I also fixes 'lint' warnings that were present in the project and added .editorconfig file to preserve formatting for other contributors.
