### PR TITLE
Fixes #19 - path option arguments don't work correctly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install via npm and then add `metalsmith-pagination` to your `metalsmith.json`:
         "perPage": 5,
         "template": "index.jade",
         "first": "index.html",
-        "path": "page/:num/index.html",
+        "path": "page/{num}/index.html",
         "filter": "private !== true",
         "pageMetadata": {
           "title": "Archive"
@@ -54,7 +54,7 @@ metalsmith.use(pagination({
     perPage: 5,
     template: 'index.jade',
     first: 'index.html',
-    path: 'page/:num/index.html',
+    path: 'page/{num}/index.html',
     filter: function (page) {
       return !page.private
     },
@@ -71,7 +71,7 @@ metalsmith.use(pagination({
 * **template** The template metadata for [metalsmith-templates](https://npmjs.org/package/metalsmith-templates).
 * **layout** The layout metadata for [metalsmith-layouts](https://npmjs.org/package/metalsmith-layouts).
 * **first** An optional path to use in place of the page one (E.g. Render as the homepage `index.html`, instead of `page/1/index.html`).
-* **path** The path to render every page under. Interpolated with the `pagination` object, so you can use `:name`, `:num`, `:index`, etc.
+* **path** The path to render every page under. Interpolated with the `pagination` object, so you can use `{name}`, `{num}`, `{index}`, etc.
 * **filter** A string or function used to filter files in pagination.
 * **pageMetadata** The metadata to merge with every page.
 * **noPageOne** Set to true to disable rendering of page one, useful in conjunction with first (default: `false`).

--- a/metalsmith-pagination.js
+++ b/metalsmith-pagination.js
@@ -163,7 +163,7 @@ module.exports = function (options) {
 function interpolate (path, data) {
   var result = path
   Object.keys(data).forEach(function (param) {
-    result = result.replace(new RegExp(':' + param, 'g'), data[param])
+    result = result.replace(new RegExp('{' + param + '}', 'g'), data[param])
   })
   return result
 }

--- a/metalsmith-pagination.js
+++ b/metalsmith-pagination.js
@@ -31,7 +31,8 @@ module.exports = function (options) {
       // Catch nested collection reference errors.
       try {
         collection = toFn(name)(metadata)
-      } catch (error) {}
+      } catch (error) {
+      }
 
       if (!collection) {
         done(new TypeError('Collection not found (' + name + ')'))
@@ -160,9 +161,11 @@ module.exports = function (options) {
  * @return {String}
  */
 function interpolate (path, data) {
-  return path.replace(/:(\w+)/g, function (match, param) {
-    return data[param]
+  var result = path
+  Object.keys(data).forEach(function (param) {
+    result = result.replace(new RegExp(':' + param, 'g'), data[param])
   })
+  return result
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -47,7 +47,7 @@ describe('metalsmith collections paginate', function () {
           perPage: 3,
           template: 'index.jade',
           first: 'articles/index.html',
-          path: 'articles/page/:num/index.html'
+          path: 'articles/page/{num}/index.html'
         }
       })(files, metalsmith, function (err) {
         var firstPage = files['articles/index.html']
@@ -118,7 +118,7 @@ describe('metalsmith collections paginate', function () {
         'collections.articles': {
           perPage: 3,
           template: 'index.jade',
-          path: 'articles/page/:num/index.html',
+          path: 'articles/page/{num}/index.html',
           pageContents: 'foobar',
           pageMetadata: {
             foo: 'bar',
@@ -160,7 +160,7 @@ describe('metalsmith collections paginate', function () {
           template: 'index.jade',
           first: 'index.html',
           noPageOne: true,
-          path: 'page/:num/index.html'
+          path: 'page/{num}/index.html'
         }
       })(files, metalsmith, function (err) {
         var firstPage = files['index.html']
@@ -180,7 +180,7 @@ describe('metalsmith collections paginate', function () {
         'collections.articles': {
           template: 'index.jade',
           first: 'index.html',
-          path: 'page/:numen.html'
+          path: 'page/{num}en.html'
         }
       })(files, metalsmith, function (err) {
         var firstPage = files['index.html']
@@ -220,7 +220,7 @@ describe('metalsmith collections paginate', function () {
         'collections.articles': {
           groupBy: 'date.getFullYear()',
           template: 'index.jade',
-          path: 'articles/:name/index.html'
+          path: 'articles/{name}/index.html'
         }
       })(files, metalsmith, function (err) {
         var pageOne = files['articles/2014/index.html']
@@ -270,7 +270,7 @@ describe('metalsmith collections paginate', function () {
           perPage: 3,
           template: 'index.jade',
           first: 'articles/index.html',
-          path: 'articles/page/:num/index.html'
+          path: 'articles/page/{num}/index.html'
         }
       })(files, metalsmith, function (err) {
         var firstPage = files['articles/index.html']
@@ -303,7 +303,7 @@ describe('metalsmith collections paginate', function () {
           filter: {
             hide: false
           },
-          path: 'articles/page/:num/index.html'
+          path: 'articles/page/{num}/index.html'
         }
       })(files, metalsmith, function (err) {
         var firstPage = files['articles/index.html']
@@ -335,7 +335,7 @@ describe('metalsmith collections paginate', function () {
           filter: function (page) {
             return !page.hide
           },
-          path: 'articles/page/:num/index.html'
+          path: 'articles/page/{num}/index.html'
         }
       })(files, metalsmith, function (err) {
         var firstPage = files['articles/index.html']

--- a/test.js
+++ b/test.js
@@ -24,13 +24,13 @@ describe('metalsmith collections paginate', function () {
     var metadata = {
       collections: {
         articles: [
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' },
-          { contents: '' }
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''},
+          {contents: ''}
         ]
       }
     }
@@ -174,6 +174,26 @@ describe('metalsmith collections paginate', function () {
         return done(err)
       })
     })
+
+    it('should replace path arguments correctly', function (done) {
+      return paginate({
+        'collections.articles': {
+          template: 'index.jade',
+          first: 'index.html',
+          path: 'page/:numen.html'
+        }
+      })(files, metalsmith, function (err) {
+        var firstPage = files['index.html']
+        var pageOne = files['page/1en.html']
+
+        expect(firstPage).to.exist
+        expect(firstPage.pagination.files.length).to.equal(7)
+
+        expect(pageOne).to.exist
+
+        return done(err)
+      })
+    })
   })
 
   describe('group by', function () {
@@ -182,9 +202,9 @@ describe('metalsmith collections paginate', function () {
     var metadata = {
       collections: {
         articles: [
-          { contents: '', date: new Date(2014, 10, 7) },
-          { contents: '', date: new Date(2014, 11, 12) },
-          { contents: '', date: new Date(2015, 9, 23) }
+          {contents: '', date: new Date(2014, 10, 7)},
+          {contents: '', date: new Date(2014, 11, 12)},
+          {contents: '', date: new Date(2015, 9, 23)}
         ]
       }
     }
@@ -227,13 +247,13 @@ describe('metalsmith collections paginate', function () {
     var metadata = {
       collections: {
         articles: [
-          { contents: '', hide: true },
-          { contents: '', hide: true },
-          { contents: '', hide: true },
-          { contents: '', hide: false },
-          { contents: '', hide: false },
-          { contents: '', hide: false },
-          { contents: '', hide: false }
+          {contents: '', hide: true},
+          {contents: '', hide: true},
+          {contents: '', hide: true},
+          {contents: '', hide: false},
+          {contents: '', hide: false},
+          {contents: '', hide: false},
+          {contents: '', hide: false}
         ]
       }
     }
@@ -429,7 +449,7 @@ describe('metalsmith collections paginate', function () {
           noPageOne: true,
           path: '123'
         }
-      })({}, instance({ posts: [] }), function (err) {
+      })({}, instance({posts: []}), function (err) {
         expect(err).to.exist
         expect(err.message).to.equal('When `noPageOne` is enabled, a first page must be set (posts)')
 


### PR DESCRIPTION
Hi,

I changed the templating syntax to {num} as you suggested. I changed readme and tests as well.
I decided not to add a string-templates dependency because the change is just two characters long.

Thanks,
